### PR TITLE
Use latest LMS 8.2's hint about which firmware to download when returning the repository base URL

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -37,7 +37,9 @@ use constant COMMUNITY_FIRMWARE_REPOSITORY => 'https://ralph_irving.gitlab.io/lm
 my $log = logger('player.firmware');
 
 sub BASE {
-	my $url = $prefs->get('enable')
+	my $hint = shift;
+
+	my $url = ($prefs->get('enable') && (!$hint || $hint =~ /jive|fab4|baby/))
 		? COMMUNITY_FIRMWARE_REPOSITORY
 		: $DEFAULT_REPOSITORY;
 


### PR DESCRIPTION
The latest 8.2 release would no longer include ip3k firmwares, thus needs LMS to download them when needed. `BASE()` would currently always point to the community firmware download page. But there's no ip3k firmware. Therefore I added a "hint" to the `BASE()` call in LMS 8.2. It's the firmware's name. Use this to decide whether we need the community firmware repository, or LMS' own.

When there's no hint we'll behave as before to not break backwards compatibility.