### PR TITLE
Override LMS 8.4+ firmware check interval

### DIFF
--- a/Plugin.pm
+++ b/Plugin.pm
@@ -37,6 +37,10 @@ use constant COMMUNITY_FIRMWARE_REPOSITORY => 'https://ralph_irving.gitlab.io/lm
 
 my $log = logger('player.firmware');
 
+sub CHECK_INTERVAL { 
+	return Slim::Utils::Prefs::preferences('server')->get('checkVersionInterval');
+}
+
 sub BASE {
 	my $hint = shift;
 


### PR DESCRIPTION
LMS 8.4 doesn't check for firmware updates on a daily basis any more, as there won't be new official firmware any more. But users of the community firmware might want to be informed of updates. Override LMS' own interval.