### PR TITLE
Add crashlog handler for Community Firmware

### DIFF
--- a/Crashlog.pm
+++ b/Crashlog.pm
@@ -1,0 +1,130 @@
+package Plugins::CommunityFirmware::Crashlog;
+
+use strict;
+
+use File::Spec::Functions qw(catfile);
+use JSON::XS::VersionOneAndTwo;
+
+use Slim::Utils::Log;
+use Slim::Utils::OSDetect;
+use Slim::Utils::Misc;
+use Slim::Player::Client;
+
+use constant MAX_UPLOAD_SIZE => 1024 * 1024;
+use constant MAX_DUMPS => 10;
+
+my $log = Slim::Utils::Log->addLogCategory({
+	'category'     => 'plugin.communityfirmware',
+	'defaultLevel' => 'ERROR',
+	'description'  => 'PLUGIN_COMMUNITY_FIRMWARE_NAME',
+});
+
+
+sub init {
+	Slim::Web::Pages->addRawFunction("plugins/CommunityFirmware/crashlog", \&handleCrashlog);
+	purgeCrashlogs();
+}
+
+sub handleCrashlog {
+	my ($httpClient, $response) = @_;
+
+	my $request = $response->request;
+	my $result = {};
+
+	main::INFOLOG && $log->is_info && $log->info("Receiving new crashlog. Size: " . formatKB($request->content_length));
+
+	purgeCrashlogs();
+
+	if ($request->method() ne 'POST') {
+		$result = {
+			error => 'Invalid request',
+			code  => 400,
+		};
+	}
+	elsif ( $request->content_length > MAX_UPLOAD_SIZE ) {
+		my $size = formatKB($request->content_length);
+		$result = {
+			error => "Refused upload of crashlog - too big: $size > " . formatKB(MAX_UPLOAD_SIZE),
+			code  => 413,
+		};
+	}
+	else {
+		# get the request data (POST for JSON 1.0)
+		my $raw = $request->content() || '{}';
+		my $json;
+		eval { $json = from_json($raw) };
+
+		if ($@) {
+			$result = {
+				error => "Failed to parse JSON: $@",
+				code  => 400,
+			};
+		}
+		else {
+			my $client = Slim::Player::Client::getClient($json->{mac});
+
+			$result = {
+				error => sprintf(
+					q{name="%s" device="%s" version="%s" mac="%s" uptime="%s" reason="%s"},
+					$client && $client->name || "unknown",
+					$json->{machine},   # device type: jive, baby, fab4
+					$json->{version},
+					$json->{mac},
+					$json->{uptime} || "unknown",
+					$json->{reason} || $json->{failure} || "unknown",
+					# $json->{uuid},
+					# $json->{logfile},
+					# $json->{reqid},
+				),
+				code => 204,
+			};
+
+			main::DEBUGLOG && $log->is_debug && $log->debug("Received crashlog data: " . Data::Dump::dump($json));
+
+			my $logFile = catfile($::logdir || Slim::Utils::OSDetect::dirsFor('log'), 'firmware_crashlog_' . time() . '.json');
+			main::INFOLOG && $log->is_info && $log->info("Saving crashlog to $logFile");
+
+			File::Slurp::write_file($logFile, to_json($json));
+		}
+	}
+
+	$log->error("Firmware Crashlog: " . $result->{error}) if $result->{error};
+
+	$response->header( 'Content-Length' => 0 );
+	$response->code($result->{code} || 204);
+	$response->header('Connection' => 'close');
+	$response->content_type('text/plain');
+
+	Slim::Web::HTTP::addHTTPResponse( $httpClient, $response, \'' );
+}
+
+sub purgeCrashlogs {
+	my $logDir = $::logdir || Slim::Utils::OSDetect::dirsFor('log');
+
+	my @dumps;
+	if ( $logDir && -d $logDir && opendir(DIR, $logDir) ) {
+		@dumps = grep { $_ =~ /\/firmware_crashlog_\d+\.json/ && -f $_ && -r _ } map { catfile($logDir, $_) } sort readdir(DIR);
+		closedir(DIR);
+	}
+
+	# keep the 10 most recent, delete the rest
+	if (@dumps > MAX_DUMPS) {
+		main::INFOLOG && $log->is_info && $log->info("Purging old crashlogs, keeping " . MAX_DUMPS . " files");
+		for my $file (@dumps[0 .. $#dumps - MAX_DUMPS]) {
+			main::DEBUGLOG && $log->is_debug && $log->debug("Deleting old crashlog $file");
+			unlink $file;
+		}
+	}
+}
+
+sub formatKB {
+	my $size = $_[0];
+
+	if ($size < 3200) {
+		return "$size Bytes";
+	}
+
+	return Slim::Utils::Misc::delimitThousands(int($size / 1024)) . ' KB';
+}
+
+1;

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -4,21 +4,14 @@ use strict;
 
 use base qw(Slim::Plugin::Base);
 use File::Spec::Functions qw(catfile);
-use JSON::XS::VersionOneAndTwo;
 
 use Slim::Utils::Firmware;
 use Slim::Utils::Prefs;
 use Slim::Utils::Log;
 
-use constant MAX_UPLOAD_SIZE => 1024 * 1024;
-use constant MAX_DUMPS => 10;
+use Plugins::CommunityFirmware::Crashlog;
 
 my $log = logger('player.firmware');
-my $cfLog = Slim::Utils::Log->addLogCategory({
-	'category'     => 'plugin.communityfirmware',
-	'defaultLevel' => 'ERROR',
-	'description'  => 'PLUGIN_COMMUNITY_FIRMWARE_NAME',
-});
 
 my $DEFAULT_REPOSITORY;
 
@@ -60,8 +53,6 @@ sub initPlugin {
 		}
 	}, 'enable');
 
-	Slim::Web::Pages->addRawFunction("plugins/CommunityFirmware/crashlog", \&handleCrashlog);
-
 	# make sure the falsy value is never undefined, or it would get re-initialised with defaults
 	$prefs->setChange(sub {
 		my ($pref, $val) = @_;
@@ -70,111 +61,7 @@ sub initPlugin {
 
 	preferences('server')->set('checkVersion', 1);
 
-	purgeCrashlogs();
-}
-
-sub handleCrashlog {
-	my ($httpClient, $response) = @_;
-
-	my $request = $response->request;
-	my $result = {};
-
-	my $t = Time::HiRes::time();
-
-	main::INFOLOG && $cfLog->is_info && $cfLog->info("Receiving new crashlog. Size: " . formatKB($request->content_length));
-
-	purgeCrashlogs();
-
-	if ($request->method() ne 'POST') {
-		$result = {
-			error => 'Invalid request',
-			code  => 400,
-		};
-	}
-	elsif ( $request->content_length > MAX_UPLOAD_SIZE ) {
-		my $size = formatKB($request->content_length);
-		$result = {
-			error => "Refused upload of crashlog - too big: $size > " . formatKB(MAX_UPLOAD_SIZE),
-			code  => 413,
-		};
-	}
-	else {
-		# get the request data (POST for JSON 1.0)
-		my $raw = $request->content() || '{}';
-		my $json;
-		eval { $json = from_json($raw) };
-
-		if ($@) {
-			$result = {
-				error => "Failed to parse JSON: $@",
-				code  => 400,
-			};
-		}
-		else {
-			my $client = Slim::Player::Client::getClient($json->{mac});
-
-			$result = {
-				error => sprintf(
-					q{name="%s" device="%s" version="%s" mac="%s" uptime="%s" reason="%s"},
-					$client && $client->name || "unknown",
-					$json->{machine},   # device type: jive, baby, fab4
-					$json->{version},
-					$json->{mac},
-					$json->{uptime} || "unknown",
-					$json->{reason} || $json->{failure} || "unknown",
-					# $json->{uuid},
-					# $json->{logfile},
-					# $json->{reqid},
-				),
-				code => 204,
-			};
-
-			main::DEBUGLOG && $cfLog->is_debug && $cfLog->debug("Received crashlog data: " . Data::Dump::dump($json));
-
-			my $logFile = catfile($::logdir || Slim::Utils::OSDetect::dirsFor('log'), 'firmware_crashlog_' . time() . '.json');
-			main::INFOLOG && $cfLog->is_info && $cfLog->info("Saving crashlog to $logFile");
-
-			File::Slurp::write_file($logFile, to_json($json));
-		}
-	}
-
-	$cfLog->error("Firmware Crashlog: " . $result->{error}) if $result->{error};
-
-	$response->header( 'Content-Length' => 0 );
-	$response->code($result->{code} || 204);
-	$response->header('Connection' => 'close');
-	$response->content_type('text/plain');
-
-	Slim::Web::HTTP::addHTTPResponse( $httpClient, $response, \'' );
-}
-
-sub purgeCrashlogs {
-	my $logDir = $::logdir || Slim::Utils::OSDetect::dirsFor('log');
-
-	my @dumps;
-	if ( $logDir && -d $logDir && opendir(DIR, $logDir) ) {
-		@dumps = grep { $_ =~ /\/firmware_crashlog_\d+\.json/ && -f $_ && -r _ } map { catfile($logDir, $_) } sort readdir(DIR);
-		closedir(DIR);
-	}
-
-	# keep the 10 most recent, delete the rest
-	if (@dumps > MAX_DUMPS) {
-		main::INFOLOG && $cfLog->is_info && $cfLog->info("Purging old crashlogs, keeping " . MAX_DUMPS . " files");
-		for my $file (@dumps[0 .. $#dumps - MAX_DUMPS]) {
-			main::DEBUGLOG && $cfLog->is_debug && $cfLog->debug("Deleting old crashlog $file");
-			unlink $file;
-		}
-	}
-}
-
-sub formatKB {
-	my $size = $_[0];
-
-	if ($size < 3200) {
-		return "$size Bytes";
-	}
-
-	return Slim::Utils::Misc::delimitThousands(int($size / 1024)) . ' KB';
+	Plugins::CommunityFirmware::Crashlog->init();
 }
 
 1;

--- a/Plugin.pm
+++ b/Plugin.pm
@@ -4,12 +4,21 @@ use strict;
 
 use base qw(Slim::Plugin::Base);
 use File::Spec::Functions qw(catfile);
+use JSON::XS::VersionOneAndTwo;
 
 use Slim::Utils::Firmware;
 use Slim::Utils::Prefs;
 use Slim::Utils::Log;
 
+use constant MAX_UPLOAD_SIZE => 1024 * 1024;
+use constant MAX_DUMPS => 10;
+
 my $log = logger('player.firmware');
+my $cfLog = Slim::Utils::Log->addLogCategory({
+	'category'     => 'plugin.communityfirmware',
+	'defaultLevel' => 'ERROR',
+	'description'  => 'PLUGIN_COMMUNITY_FIRMWARE_NAME',
+});
 
 my $DEFAULT_REPOSITORY;
 
@@ -51,6 +60,8 @@ sub initPlugin {
 		}
 	}, 'enable');
 
+	Slim::Web::Pages->addRawFunction("plugins/CommunityFirmware/crashlog", \&handleCrashlog);
+
 	# make sure the falsy value is never undefined, or it would get re-initialised with defaults
 	$prefs->setChange(sub {
 		my ($pref, $val) = @_;
@@ -58,6 +69,112 @@ sub initPlugin {
 	}, 'enable', 'beta');
 
 	preferences('server')->set('checkVersion', 1);
+
+	purgeCrashlogs();
+}
+
+sub handleCrashlog {
+	my ($httpClient, $response) = @_;
+
+	my $request = $response->request;
+	my $result = {};
+
+	my $t = Time::HiRes::time();
+
+	main::INFOLOG && $cfLog->is_info && $cfLog->info("Receiving new crashlog. Size: " . formatKB($request->content_length));
+
+	purgeCrashlogs();
+
+	if ($request->method() ne 'POST') {
+		$result = {
+			error => 'Invalid request',
+			code  => 400,
+		};
+	}
+	elsif ( $request->content_length > MAX_UPLOAD_SIZE ) {
+		my $size = formatKB($request->content_length);
+		$result = {
+			error => "Refused upload of crashlog - too big: $size > " . formatKB(MAX_UPLOAD_SIZE),
+			code  => 413,
+		};
+	}
+	else {
+		# get the request data (POST for JSON 1.0)
+		my $raw = $request->content() || '{}';
+		my $json;
+		eval { $json = from_json($raw) };
+
+		if ($@) {
+			$result = {
+				error => "Failed to parse JSON: $@",
+				code  => 400,
+			};
+		}
+		else {
+			my $client = Slim::Player::Client::getClient($json->{mac});
+
+			$result = {
+				error => sprintf(
+					q{name="%s" device="%s" version="%s" mac="%s" uptime="%s" reason="%s"},
+					$client && $client->name || "unknown",
+					$json->{machine},   # device type: jive, baby, fab4
+					$json->{version},
+					$json->{mac},
+					$json->{uptime} || "unknown",
+					$json->{reason} || $json->{failure} || "unknown",
+					# $json->{uuid},
+					# $json->{logfile},
+					# $json->{reqid},
+				),
+				code => 204,
+			};
+
+			main::DEBUGLOG && $cfLog->is_debug && $cfLog->debug("Received crashlog data: " . Data::Dump::dump($json));
+
+			my $logFile = catfile($::logdir || Slim::Utils::OSDetect::dirsFor('log'), 'firmware_crashlog_' . time() . '.json');
+			main::INFOLOG && $cfLog->is_info && $cfLog->info("Saving crashlog to $logFile");
+
+			File::Slurp::write_file($logFile, to_json($json));
+		}
+	}
+
+	$cfLog->error("Firmware Crashlog: " . $result->{error}) if $result->{error};
+
+	$response->header( 'Content-Length' => 0 );
+	$response->code($result->{code} || 204);
+	$response->header('Connection' => 'close');
+	$response->content_type('text/plain');
+
+	Slim::Web::HTTP::addHTTPResponse( $httpClient, $response, \'' );
+}
+
+sub purgeCrashlogs {
+	my $logDir = $::logdir || Slim::Utils::OSDetect::dirsFor('log');
+
+	my @dumps;
+	if ( $logDir && -d $logDir && opendir(DIR, $logDir) ) {
+		@dumps = grep { $_ =~ /\/firmware_crashlog_\d+\.json/ && -f $_ && -r _ } map { catfile($logDir, $_) } sort readdir(DIR);
+		closedir(DIR);
+	}
+
+	# keep the 10 most recent, delete the rest
+	if (@dumps > MAX_DUMPS) {
+		main::INFOLOG && $cfLog->is_info && $cfLog->info("Purging old crashlogs, keeping " . MAX_DUMPS . " files");
+		for my $file (@dumps[0 .. $#dumps - MAX_DUMPS]) {
+			main::DEBUGLOG && $cfLog->is_debug && $cfLog->debug("Deleting old crashlog $file");
+			unlink $file;
+		}
+	}
+}
+
+sub formatKB {
+	my $size = $_[0];
+
+	if ($size < 3200) {
+		return "$size Bytes";
+	}
+
+	return Slim::Utils::Misc::delimitThousands(int($size / 1024)) . ' KB';
 }
 
 1;

--- a/strings.txt
+++ b/strings.txt
@@ -1,3 +1,9 @@
+PLUGIN_COMMUNITY_FIRMWARE_NAME
+	DE	Community-Firmware für Touch/Radio/Controller
+	EN	Community Firmware for Touch/Radio/Controller
+	FR	Micrologiciel communautaire pour écran tactile/radio/contrôleur
+	NL	Community Firmware voor Touch/Radio/Controller
+
 PLUGIN_COMMUNITY_FIRMWARE
 	DE	Community-Firmware f&uuml;r Touch/Radio/Controller
 	EN	Community Firmware for Touch/Radio/Controller


### PR DESCRIPTION
Add a web handler to which the firmware can `POST` the crashlog. Accepts up to 1MB of data, logs a summary in `server.log`, dumps the full JSON data in the log folder (up to 10 files).

I believe the call from the firmware is something like this:

```
curl --request POST \
  --url http://yourserver:9000/plugins/CommunityFirmware/crashlog \
  --header 'content-type: application/json' \
  --data '{
  "machine": "jive",
  "mac": "56:ab:cd:ef:12:34",
  "version": "1.2.3",
  "uptime": 12345,
  "failure": "testing, what else?",
  "uuid": "123234234",
  "logfile": "a lot of log file content?\nand more?\ndon'\''t know.",
  "requid": "what-ever-this?"
}'
```

I'm not sure about the "logfile" element, whether that would indeed include a full file dump. To be verified with actual firmware.

This is based on https://github.com/ralph-irving/squeezeos-squeezeplay/blob/public/9.0/src/squeezeplay_squeezeos/share/applets/CrashLog/CrashLogApplet.lua#L131 and legacy code from MySB. So this seems to not be zipped data, but rather a JSON object. Maybe the log file is some binary? Would probably mess the output.